### PR TITLE
added: implement FilamentUser interface and add panel access control m…

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,6 +4,8 @@ namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use App\Enums\RoleEnum;
+use Filament\Models\Contracts\FilamentUser;
+use Filament\Panel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
@@ -12,7 +14,7 @@ use Illuminate\Support\Str;
 use Laravel\Sanctum\HasApiTokens;
 use Spatie\Permission\Traits\HasRoles;
 
-class User extends Authenticatable
+class User extends Authenticatable implements FilamentUser
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
     use HasApiTokens, HasFactory, Notifiable;
@@ -69,5 +71,14 @@ class User extends Authenticatable
     public function appointments(): HasMany
     {
         return $this->hasMany(Appointment::class);
+    }
+
+    public function canAccessPanel(Panel $panel): bool
+    {
+        if ($panel->getId() === 'admin') {
+            return str_ends_with($this->email, '@dev.com');
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
This pull request updates the `User` model to integrate with the Filament admin panel by implementing the `FilamentUser` interface and adding a method to control panel access. Below are the key changes:

### Integration with Filament:

* Added `Filament\Models\Contracts\FilamentUser` and `Filament\Panel` imports to the `User` model. (`app/Models/User.php`, [app/Models/User.phpR7-R8](diffhunk://#diff-37a2d7d879a7de3f7d73b2975cd22be9f41ec10c334a0dda9ad1e869332e4ecbR7-R8))
* Updated the `User` class to implement the `FilamentUser` interface, enabling it to be used with Filament's admin panel. (`app/Models/User.php`, [app/Models/User.phpL15-R17](diffhunk://#diff-37a2d7d879a7de3f7d73b2975cd22be9f41ec10c334a0dda9ad1e869332e4ecbL15-R17))

### Panel Access Control:

* Added the `canAccessPanel(Panel $panel): bool` method to the `User` model. This method restricts access to the `admin` panel to users with emails ending in `@dev.com`. (`app/Models/User.php`, [app/Models/User.phpR75-R83](diffhunk://#diff-37a2d7d879a7de3f7d73b2975cd22be9f41ec10c334a0dda9ad1e869332e4ecbR75-R83))…ethod